### PR TITLE
Correct MacGap Docs URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 <a name="support-or-contact" class="anchor" href="#support-or-contact"><span class="octicon octicon-link"></span></a>Support or Contact</h3>
 
 <p>  
-  Having trouble with MacGap? Check out the documentation at <a href="http://help.github.com/pages">http://help.github.com/pages</a> or open an issue in our <a href="https://github.com/MacGapProject/MacGap2/issues">Issue Tracker</a> and we’ll help you sort it out.
+  Having trouble with MacGap? Check out the documentation at <a href="http://docs.macgap.com/">http://docs.macgap.com/</a> or open an issue in our <a href="https://github.com/MacGapProject/MacGap2/issues">Issue Tracker</a> and we’ll help you sort it out.
 </p>
       </section>
     </div>


### PR DESCRIPTION
Current home page lists http://help.github.com/docs:

> Having trouble with MacGap? Check out the documentation at http://help.github.com/pages or open an issue in our Issue Tracker and we’ll help you sort it out.

This corrects it to http://docs.macgap.com.